### PR TITLE
Add Cocoapods support

### DIFF
--- a/CodableCSV.podspec
+++ b/CodableCSV.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |s|
+  s.name             = 'CodableCSV'
+  s.version          = '0.2.0'
+  s.summary          = "Read and write CSV files row-by-row or through Swift's Codable interface."
+
+  s.homepage         = 'https://github.com/dehesa/CodableCSV'
+  s.license          = { :type => 'MIT', :file => 'LICENSE' }
+  s.author           = { 'dehesa' => 'san.dehesa@gmail.com' }
+  s.source           = { :git => 'https://github.com/dehesa/CodableCSV.git', :tag => s.version.to_s }
+  # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'
+
+  s.ios.deployment_target = '12.0'
+
+  s.source_files = 'Souces/**/*'
+end

--- a/CodableCSV.podspec
+++ b/CodableCSV.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'CodableCSV'
-  s.version          = '0.2.0'
+  s.version          = '0.3.0'
   s.summary          = "Read and write CSV files row-by-row or through Swift's Codable interface."
 
   s.homepage         = 'https://github.com/dehesa/CodableCSV'


### PR DESCRIPTION
As the maintainer, you will probably want to submit this to the spec repo yourself (https://guides.cocoapods.org/making/making-a-cocoapod.html), but this will at least allow users to use the library using a manual git link: `pod 'CodableCSV', git: 'https://github.com/dehesa/CodableCSV.git'`.