### PR TITLE
Documentation correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ struct Student: Decodable {
     let age: Int
     let hasPet: Bool
 
-    init(from decoder: Decoder) {
-        var row = try decoder.unkeyedContainer
+    init(from decoder: Decoder) throws {
+        var row = try decoder.unkeyedContainer()
         self.name = try row.decode(String.self)
         self.age = try row.decode(Int.self)
         self.hasPet = try row.decode(Boolean.self)

--- a/Sources/Active/Writer/Writer.swift
+++ b/Sources/Active/Writer/Writer.swift
@@ -90,12 +90,12 @@ public final class CSVWriter {
             throw Error.outputStreamFailed(message: "The stream couldn't be open.", underlyingError: output.stream.streamError)
         }
         
-        if !self.settings.headers.isEmpty {
-            try self.write(row: self.settings.headers)
-        }
-            
         self.state = (.started(nextIndex: 0), .unstarted)
-    }
+ 
+        if !self.settings.headers.isEmpty {
+              try self.write(row: self.settings.headers)
+          }
+}
     
     /// Starts a new CSV row.
     ///


### PR DESCRIPTION
Fixes a small issue in the documentation so that the sample code properly compiles.

I also fixed an issue in the encoder where writing headers in an initialized state would start the file over and get into a recursion loop. Setting the state before writing the headers fixed it.