### PR TITLE
Add "headers" Row state

### DIFF
--- a/Sources/Active/Writer/WriterSettings.swift
+++ b/Sources/Active/Writer/WriterSettings.swift
@@ -67,6 +67,8 @@ extension CSVWriter {
         internal enum Row {
             /// A new row hasn't been started yet.
             case unstarted
+            /// The headers are being written
+            case headers
             /// The row has been started and `fields` amount of fields have been writen to it.
             ///
             /// `nextIndex` indicate the index of the field to write next.
@@ -76,6 +78,7 @@ extension CSVWriter {
             var nextIndex: Int {
                 switch self {
                 case .unstarted: return 0
+                case .headers: return 0
                 case .started(let fields): return fields
                 }
             }

--- a/Tests/CodableCSVTests/ActiveTests/WriterTests.swift
+++ b/Tests/CodableCSVTests/ActiveTests/WriterTests.swift
@@ -61,4 +61,32 @@ extension CSVWriterTests {
             }
         }
     }
+    
+    /// Test to ensure that the writer's indicies row count is equal
+    /// to the number of rows in the data, not including the header
+    func testIndices() throws {
+        let input = TestData.Arrays.genericNoHeader
+        let headers = ["seq", "Name", "Country", "Number Pair"]
+        
+        let config = EncoderConfiguration(fieldDelimiter: .comma, rowDelimiter: .lineFeed, headers: headers)
+        
+        let expectedRowCount = input.count
+        
+        let stream = OutputStream(toMemory: ())
+        
+        guard let encoder = String.Encoding.utf8.scalarEncoder else {
+            throw CSVWriter.Error.unsupportedEncoding(String.Encoding.utf8)
+        }
+        let writer = try CSVWriter(output: (stream, true), configuration: config, encoder: encoder)
+
+        try writer.beginFile()
+        for row in input {
+            try writer.write(row: row)
+        }
+        try writer.endFile()
+        
+        XCTAssertEqual(expectedRowCount, writer.indices.row)
+        
+    }
+
 }

--- a/Tests/CodableCSVTests/CodableTests/EncodingAppleCardExports.swift
+++ b/Tests/CodableCSVTests/CodableTests/EncodingAppleCardExports.swift
@@ -1,0 +1,110 @@
+import CodableCSV
+import XCTest
+
+/// Tests for the encodable Apple Card data.
+final class EncodingAppleCardTests: XCTestCase {
+    // List of all tests to run through SPM.
+    static let allTests = [
+        ("testTransactions", testTransactions)
+    ]
+    
+    override func setUp() {
+        self.continueAfterFailure = false
+    }
+}
+
+extension EncodingAppleCardTests {
+    /// Test data used throughout this `XCTestCase`.
+    private enum TestData {
+        /// The column names for the CSV.
+        static let header: [String] = ["transactionDate", "clearingDate", "description", "merchant", "category", "type", "amount"]
+        /// List of transactions.
+        static let array: [[String]] = [
+            ["10/04/2019", "10/04/2019", "Merchant A on Main Street",                          "Merchant A",      "Restaurants", "Purchase", "10.70"   ],
+            ["09/31/2019", "09/31/2019", "A Payment",                                          "The Bank",        "Other",       "Payment",  "-340.54" ],
+            ["09/24/2019", "09/24/2019", "Apple ONE APPLE PARK WAY 866-712-7753 95014 CA USA", "Apple Services",  "Other",       "Purchase", "14.68"   ],
+            ["09/17/2019", "09/17/2019", "Apple ONE APPLE PARK WAY 866-712-7753 95014 CA USA", "Apple Services",  "Other",       "Purchase", "53.49"   ],
+            ["09/05/2019", "09/06/2019", "Full On Artwork",                                    "Full On Artwork", "Other",       "Purchase", "100.02"  ],
+            ["09/01/2019", "09/01/2019", "Seafood by the Bay",                                 "Salty's",         "Restaurants", "Purchase", "98.32"   ]
+        ]
+        /// Configuration used to generated the CSV data.
+        static let decoderConfiguration = DecoderConfiguration(fieldDelimiter: .comma, rowDelimiter: .lineFeed, headerStrategy: .firstLine)
+        /// Configuration used to read the CSV data.
+        static let encoderConfiguration = EncoderConfiguration(fieldDelimiter: .comma, rowDelimiter: .lineFeed, headers: TestData.header)
+        /// String version of the test data.
+        static let string: String = ([header] + array).toCSV(delimiters: decoderConfiguration.delimiters)
+        /// Data version of the test data.
+        static let blob: Data = ([header] + array).toCSV(delimiters: decoderConfiguration.delimiters)!
+    }
+}
+
+extension EncodingAppleCardTests {
+    /// Description of a CSV row.
+    private struct Transaction: Codable {
+        let transactionDate: String
+        let clearingDate: String
+        let description: String
+        let merchant: String
+        let category: String
+        let type: String
+        var amount: String
+  
+        init(from decoder: Decoder) throws {
+            var row = try decoder.unkeyedContainer()
+            self.transactionDate = try row.decode(String.self)
+            self.clearingDate = try row.decode(String.self)
+            self.description = try row.decode(String.self)
+            self.merchant = try row.decode(String.self)
+            self.category = try row.decode(String.self)
+            self.type = try row.decode(String.self)
+            self.amount = try row.decode(String.self)
+         }
+
+        func encode(to encoder: Encoder) throws {
+            var row = encoder.unkeyedContainer()
+            try row.encode(self.transactionDate)
+            try row.encode(self.clearingDate)
+            try row.encode(self.description)
+            try row.encode(self.merchant)
+            try row.encode(self.category)
+            try row.encode(self.type)
+            try row.encode(self.amount)
+        }
+
+    }
+    
+    /// Decodes the list of transactions
+    /// then encodes them
+    func testTransactions() throws {
+        let decoder = CSVDecoder(configuration: TestData.decoderConfiguration)
+        let transactions = try decoder.decode([Transaction].self, from: TestData.blob, encoding: .utf8)
+        
+        for (index, transaction) in transactions.enumerated() {
+            let testTransaction = TestData.array[index]
+            XCTAssertEqual(transaction.transactionDate, testTransaction[0])
+            XCTAssertEqual(transaction.clearingDate, testTransaction[1])
+            XCTAssertEqual(transaction.description, testTransaction[2])
+            XCTAssertEqual(transaction.merchant, testTransaction[3])
+            XCTAssertEqual(transaction.category, testTransaction[4])
+            XCTAssertEqual(transaction.type, testTransaction[5])
+            XCTAssertEqual(transaction.amount, testTransaction[6])
+        }
+                
+        let encoder = CSVEncoder(configuration: TestData.encoderConfiguration)
+        let encodedTransactions = try encoder.encode(transactions)
+        
+        let decodedTransactions = try decoder.decode([Transaction].self, from: encodedTransactions, encoding: .utf8)
+
+        for (index, transaction) in decodedTransactions.enumerated() {
+             let testTransaction = TestData.array[index]
+             XCTAssertEqual(transaction.transactionDate, testTransaction[0])
+             XCTAssertEqual(transaction.clearingDate, testTransaction[1])
+             XCTAssertEqual(transaction.description, testTransaction[2])
+             XCTAssertEqual(transaction.merchant, testTransaction[3])
+             XCTAssertEqual(transaction.category, testTransaction[4])
+             XCTAssertEqual(transaction.type, testTransaction[5])
+             XCTAssertEqual(transaction.amount, testTransaction[6])
+         }
+
+    }
+}


### PR DESCRIPTION
Do nothing when writing headers, maining initialized status as far as the rows are concerned.
Added unit tests for both the indicies, and decoding/encoding/decoding data with headers.

I am still grokking your design, so feel free to reject if I went entirely in the wrong direction. From what I could see of the state machine, it looks like the file has a state, and the rows have a state. I figured since the output is all about the rows, the headers live in a limbo of the file being initialized, but the rows not yet started.

So I added a new state to Rows to indicate that we are writing headers, and changed the code to, when initialized, to not do anything special if we are writing headers, otherwise begin the file as normal.

For the rest of the places where Row is checked and the state is headers, I treated it in the same manner as initialized.

I added a bunch of tests (not sure why I had to add an init/decode to my test struct, but I could not encode/decode without it), reverted my changes from last night and made sure the test failed (it did, 4 did not match 5) I then applied the changes, and all tests passed.