### PR TITLE
Configure escaping scalar

### DIFF
--- a/Sources/Active/Reader/ReaderConfiguration.swift
+++ b/Sources/Active/Reader/ReaderConfiguration.swift
@@ -66,6 +66,10 @@ extension CSVReader {
             self.trimCharacters = configuration.trimStrategry
             // 3. Set the escaping scalar.
             self.escapingScalar = configuration.escapingStrategy.scalar
+            // 4. Ensure trim character set does not include escaping scalar
+            if let escapingScalar = escapingScalar, trimCharacters.contains(escapingScalar) {
+                throw Error.invalidTrimCharacter(escapingScalar: escapingScalar, trimCharacters: trimCharacters)
+            }
         }
     }
 }
@@ -78,5 +82,12 @@ fileprivate extension CSVReader.Error {
               reason: "The field and row delimiters cannot be the same.",
               help: "Set different delimiters for field and rows.",
               userInfo: ["Delimiter": delimiter])
+    }
+
+    static func invalidTrimCharacter(escapingScalar: Unicode.Scalar, trimCharacters: CharacterSet) -> CSVError<CSVReader> {
+        .init(.invalidConfiguration,
+              reason: "The trim characters set can not include the escaping scalar.",
+              help: "Remove the escaping scalar from the trim characters set.",
+              userInfo: ["Escaping scalar": escapingScalar, "Trim characters": trimCharacters])
     }
 }

--- a/Sources/Active/Reader/ReaderConfiguration.swift
+++ b/Sources/Active/Reader/ReaderConfiguration.swift
@@ -38,7 +38,7 @@ extension CSVReader {
         /// The characters set to be trimmed at the beginning and ending of each field.
         let trimCharacters: CharacterSet
         /// The unicode scalar used as encapsulator and escaping character (when printed two times).
-        let escapingScalar: Unicode.Scalar = "\""
+        let escapingScalar: Unicode.Scalar? = "\""
         
         /// Creates the inmutable reader settings from the user provided configuration values.
         /// - parameter configuration: The configuration values provided by the API user.

--- a/Sources/Active/Reader/ReaderConfiguration.swift
+++ b/Sources/Active/Reader/ReaderConfiguration.swift
@@ -9,6 +9,8 @@ extension CSVReader {
         public var headerStrategy: Strategy.Header
         /// Trims the given characters at the beginning and end of each row, and between fields.
         public var trimStrategry: CharacterSet
+        /// The strategy for escaping quoted fields.
+        public var escapingStrategy: Strategy.Escaping
         /// The encoding used to identify the underlying data or `nil` if you want the CSV reader to try to figure it out.
         ///
         /// If no encoding is provided and the input data doesn't contain a Byte Order Marker (BOM), UTF8 is presumed.
@@ -24,6 +26,7 @@ extension CSVReader {
             self.delimiters = (field: ",", row: "\n")
             self.headerStrategy = .none
             self.trimStrategry = .init()
+            self.escapingStrategy = .doubleQuote
             self.encoding = nil
             self.presample = false
         }
@@ -38,7 +41,7 @@ extension CSVReader {
         /// The characters set to be trimmed at the beginning and ending of each field.
         let trimCharacters: CharacterSet
         /// The unicode scalar used as encapsulator and escaping character (when printed two times).
-        let escapingScalar: Unicode.Scalar? = "\""
+        let escapingScalar: Unicode.Scalar?
         
         /// Creates the inmutable reader settings from the user provided configuration values.
         /// - parameter configuration: The configuration values provided by the API user.
@@ -61,6 +64,8 @@ extension CSVReader {
             }
             // 2. Set the trim characters set.
             self.trimCharacters = configuration.trimStrategry
+            // 3. Set the escaping scalar.
+            self.escapingScalar = configuration.escapingStrategy.scalar
         }
     }
 }

--- a/Sources/Active/Writer/WriterConfiguration.swift
+++ b/Sources/Active/Writer/WriterConfiguration.swift
@@ -53,7 +53,7 @@ extension CSVWriter {
         /// Boolean indicating whether the received CSV contains a header row or not.
         let headers: [String]
         /// The unicode scalar used as encapsulator and escaping character (when printed two times).
-        let escapingScalar: Unicode.Scalar = "\""
+        let escapingScalar: Unicode.Scalar? = "\""
         /// The encoding used to identify the underlying data.
         let encoding: String.Encoding
 

--- a/Sources/Active/Writer/WriterConfiguration.swift
+++ b/Sources/Active/Writer/WriterConfiguration.swift
@@ -3,6 +3,8 @@ extension CSVWriter {
     public struct Configuration {
         /// The field and row delimiters.
         public var delimiters: Delimiter.Pair
+        /// The strategy for escaping quoted fields.
+        public var escapingStrategy: Strategy.Escaping
         /// The row of headers to write at the beginning of the CSV data.
         ///
         /// If empty, no row will be written.
@@ -19,6 +21,7 @@ extension CSVWriter {
         /// Designated initlaizer setting the default values.
         public init() {
             self.delimiters = (field: ",", row: "\n")
+            self.escapingStrategy = .doubleQuote
             self.headers = .init()
             self.encoding = nil
             self.bomStrategy = .convention
@@ -53,7 +56,7 @@ extension CSVWriter {
         /// Boolean indicating whether the received CSV contains a header row or not.
         let headers: [String]
         /// The unicode scalar used as encapsulator and escaping character (when printed two times).
-        let escapingScalar: Unicode.Scalar? = "\""
+        let escapingScalar: Unicode.Scalar?
         /// The encoding used to identify the underlying data.
         let encoding: String.Encoding
 
@@ -71,6 +74,7 @@ extension CSVWriter {
                 self.delimiters = (.init(field), .init(row))
             }
             // 2. Copy all other values.
+            self.escapingScalar = configuration.escapingStrategy.scalar
             self.headers = configuration.headers
             self.encoding = encoding
         }

--- a/Sources/Strategy.swift
+++ b/Sources/Strategy.swift
@@ -16,6 +16,32 @@ public enum Strategy {
         }
     }
     
+    /// The strategy for escaping quoted fields.
+    public enum Escaping: ExpressibleByNilLiteral, ExpressibleByUnicodeScalarLiteral {
+        /// CSV delimiters can not be escaped.
+        case none
+        /// Ignore delimiter with in a scalar pair.
+        case scalar(Unicode.Scalar)
+
+        /// Escape double quoted values.
+        public static let doubleQuote: Self = "\""
+
+        public init(nilLiteral: ()) { self = .none }
+        
+        public init(unicodeScalarLiteral value: Unicode.Scalar) {
+            self = .scalar(value)
+        }
+
+        var scalar: Unicode.Scalar? {
+            switch self {
+            case .none:
+                return nil
+            case .scalar(let scalar):
+                return scalar
+            }
+        }
+    }
+
     /// The strategy to use for non-standard floating-point values (IEEE 754 infinity and NaN).
     public enum NonConformingFloat {
         /// Throw upon encountering non-conforming values. This is the default strategy.

--- a/Tests/CodableCSVTests/ActiveTests/ReaderTests.swift
+++ b/Tests/CodableCSVTests/ActiveTests/ReaderTests.swift
@@ -83,6 +83,7 @@ extension ReaderTests {
         let fieldDelimiters: [Delimiter.Field] = [",", ";", "\t", "|", "||", "|-|"]
         let headerStrategy: [Strategy.Header] = [.none, .firstLine, /*.unknown*/]
         let trimStrategy: [CharacterSet] = [.init(), .whitespaces]
+        let escapingStrategy: [Strategy.Escaping] = [.none, .doubleQuote]
         let presamples: [Bool] = [true, false]
         // The data used for testing.
         let (headers, content) = (TestData.headers, TestData.content)
@@ -126,15 +127,18 @@ extension ReaderTests {
                         var toTrim = t
                         if f.rawValue.count == 1, t.contains(f.rawValue.first!) { toTrim.remove(f.rawValue.first!) }
                         if r.rawValue.count == 1, t.contains(r.rawValue.first!) { toTrim.remove(r.rawValue.first!) }
-                        
-                        for p in presamples {
-                            var c = CSVReader.Configuration()
-                            c.delimiters = pair
-                            c.headerStrategy = h
-                            c.trimStrategry = toTrim
-                            c.presample = p
-                            
-                            XCTAssertNoThrow(try work(c, encoded))
+
+                        for e in escapingStrategy {
+                            for p in presamples {
+                                var c = CSVReader.Configuration()
+                                c.delimiters = pair
+                                c.headerStrategy = h
+                                c.trimStrategry = toTrim
+                                c.escapingStrategy = e
+                                c.presample = p
+
+                                XCTAssertNoThrow(try work(c, encoded))
+                            }
                         }
                     }
                 }

--- a/Tests/CodableCSVTests/ActiveTests/WriterTests.swift
+++ b/Tests/CodableCSVTests/ActiveTests/WriterTests.swift
@@ -49,6 +49,7 @@ extension WriterTests {
         // The configuration values to be tested.
         let rowDelimiters: [Delimiter.Row] = ["\n", "\r", "\r\n", "**~**"]
         let fieldDelimiters: [Delimiter.Field] = [",", ";", "\t", "|", "||", "|-|"]
+        let escapingStrategy: [Strategy.Escaping] = [.none, .doubleQuote]
         let encodings: [String.Encoding] = [.utf8, .utf16LittleEndian, .utf16BigEndian, .utf16LittleEndian, .utf32BigEndian]
         // The data used for testing.
         let headers = TestData.headers
@@ -69,13 +70,16 @@ extension WriterTests {
                 let pair: Delimiter.Pair = (f, r)
                 let sample = TestData.toCSV(input, delimiters: pair)
                 
-                for encoding in encodings {
-                    var c = CSVWriter.Configuration()
-                    c.delimiters = pair
-                    c.headers = headers
-                    c.encoding = encoding
-                    c.bomStrategy = .never
-                    try work(c, sample)
+                for escaping in escapingStrategy {
+                    for encoding in encodings {
+                        var c = CSVWriter.Configuration()
+                        c.delimiters = pair
+                        c.escapingStrategy = escaping
+                        c.headers = headers
+                        c.encoding = encoding
+                        c.bomStrategy = .never
+                        try work(c, sample)
+                    }
                 }
             }
         }


### PR DESCRIPTION
Hi @dehesa, thanks for publishing this library and keeping it super well documented. The code looks great.

I'm currently trying to parse a foreign TSV file that includes unescaped `"` characters in it's fields. I did see `escapingScalar` was exposed as an internal setting but wasn't publicly configurable. For my use case, disabling field escaping worked perfect. And it would be great to expose this ability on the reader configuration.

I added a new enum for _"escaping strategy"_. My use case fits into the new `.none` case. And the default case is `.doubleQuote`. Though, I was wondering if we should definite the options narrowly and just provide the two, or allow for any character to be used as a escaping pair. Maybe there's a single quoted escaped CSV out there? Would love to hear your thoughts.

Thanks!
@josh