### PR TITLE
Make CSVReader IteratorProtocol safe

### DIFF
--- a/sources/Active/Reader/Reader.swift
+++ b/sources/Active/Reader/Reader.swift
@@ -64,11 +64,19 @@ public final class CSVReader: IteratorProtocol, Sequence {
 }
 
 extension CSVReader {
-    /// Advances to the next row and returns it, or `nil` if no next row exists.
-    /// - warning: If the CSV file being parsed contains invalid characters, this function will crash. For safer parsing use `parseRow()`.
+    /// Advances to the next row and returns result of parsing it, or `nil` if no next row exists.
     /// - seealso: parseRow()
-    @inlinable public func next() -> [String]? {
-        return try! self.parseRow()
+    @inlinable public func next() -> Result<[String], Swift.Error>? {
+        do {
+            if let row = try self.parseRow() {
+                return .success(row)
+            } else {
+                // Return unwrapped nil to conform to IteratorProtocol
+                return nil
+            }
+        } catch {
+            return .failure(error)
+        }
     }
     
     /// Parses a CSV row and wraps it in a convenience structure giving accesses to fields through header titles/names.


### PR DESCRIPTION
Hey @dehesa,

This one is more of a direction for an idea rather than a concrete change.

I do really like the Sequence reading API. I'm working with a very large CSV file (in the gigabytes) can't parse it all at once. But the current design has the documented downside of crashing on bad data.

Maybe the iterator can just return a `Result` capturing the row or error instead? I think this could be a good start, but it would be a backwards incompatible change. I do like that it removes a `try!` from a public facing API.

This change only allows for iterating over parsed rows `[String]` but iterating over parsed records `Record` could also be nice. Though, I suppose what I really want is a Sequence for the decoder.

Another direction would be to deprecate `CSVReader` being an `IteratorProtocol` itself and offer subtypes for multiple ways of iteration. And there was can choose to return a `Result` instead.

```swift
reader.makeRowIterator() // RowIterator
reader.makeRecordIterator() // RecordIterator
reader.makeDecoderIterator(CustomType.self) // DecodingIterator

// or

reader.rows // Sequence (RowIterator)
reader.records // Sequence (RecordIterator)
reader.decoding(CustomType.self) // Sequence (DecodingIterator)
```

Thanks for reading!
Josh