### PR TITLE
Create CSVReader from InputStream

### DIFF
--- a/sources/imperative/ReaderUtils.swift
+++ b/sources/imperative/ReaderUtils.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+extension InputStream {
+    /// Stream for reading from stdin.
+    public static var stdin: InputStream {
+        return InputStream(fileAtPath: "/dev/stdin")!
+    }
+}
+
+internal extension Data {
+    /// Initialize Data by reading entire input stream. May throw a stream error.
+    /// - parameter stream: Stream to read.
+    /// - parameter chunk: Chunk size.
+    /// - throws: An NSError object representing the stream error.
+    init(stream: InputStream, chunk: Int) throws {
+        stream.open()
+        defer { stream.close() }
+
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: chunk)
+        defer { buffer.deallocate() }
+
+        self.init()
+
+        while stream.hasBytesAvailable {
+            let count = stream.read(buffer, maxLength: chunk)
+
+            guard count > 0 else {
+                if let error = stream.streamError {
+                    throw error
+                }
+                break
+            }
+
+            append(buffer, count: count)
+        }
+    }
+}

--- a/sources/imperative/reader/ReaderAPI.swift
+++ b/sources/imperative/reader/ReaderAPI.swift
@@ -49,6 +49,21 @@ extension CSVReader {
         } else {
             // B. Otherwise, create an input stream and start parsing byte-by-byte.
             guard let stream = InputStream(url: input) else { throw Error._invalidFile(url: input) }
+            try self.init(input: stream, configuration: configuration)
+        }
+    }
+
+    /// Creates a reader instance that will be used to parse the given CSV stream.
+    ///
+    /// If the configuration's encoding hasn't been set and the input data doesn't contain a Byte Order Marker (BOM), UTF8 is presumed.
+    /// - parameter input: The stream to be parsed.
+    /// - parameter configuration: Recipe detailing how to parse the CSV data (i.e. encoding, delimiters, etc.).
+    /// - throws: `CSVError<CSVReader>` exclusively.
+    public convenience init(input stream: InputStream, configuration: Configuration = .init()) throws {
+        if configuration.presample {
+            // A. If the `presample` configuration has been set, the file can be completely load into memory.
+            try self.init(input: try Data(stream: stream, chunk: 1024), configuration: configuration); return
+        } else {
             // B.1. Open the stream for usage.
             assert(stream.streamStatus == .notOpen)
             stream.open()
@@ -102,6 +117,17 @@ extension CSVReader {
     /// - parameter configuration: Default configuration values for the `CSVReader`.
     /// - throws: `CSVError<CSVReader>` exclusively.
     @inlinable public convenience init(input: URL, setter: (_ configuration: inout Configuration)->Void) throws {
+        var configuration = Configuration()
+        setter(&configuration)
+        try self.init(input: input, configuration: configuration)
+    }
+
+    /// Creates a reader instance that will be used to parse the given CSV stream.
+    /// - parameter input: The stream type to be parsed.
+    /// - parameter setter: Closure receiving the default parsing configuration values and letting you  change them.
+    /// - parameter configuration: Default configuration values for the `CSVReader`.
+    /// - throws: `CSVError<CSVReader>` exclusively.
+    @inlinable public convenience init(input: InputStream, setter: (_ configuration: inout Configuration)->Void) throws {
         var configuration = Configuration()
         setter(&configuration)
         try self.init(input: input, configuration: configuration)


### PR DESCRIPTION
Hey @dehesa, had another idea for a feature. 

Specifically, I was looking for some way to create a `CSVReader` reader from stdin.

Since reading from a URL was already implemented on top of `InputStream`, it seemed like exposing a public API to accept streams directly could work.

```swift
CSVReader(input: InputStream(fileAtPath: "/dev/stdin"))
```

I also saw there's a `FileHandle` API could maybe accomplish something similar. But I'm not sure how we'd implement converting a `FileHandle` -> `InputStream`

```swift
CSVReader(input: FileHandle.standardInput)
```

I'm just noting this as a possible alternative direction. I'm not too familiar with the differences between the APIs. Please share any historical knowledge if you have any 😄 

This PR is a draft attempt at the `InputStream` approach. Will add tests and clean it up if you think it's a good idea.

Thanks!
@josh 