### PR TITLE
Bump minimum iOS deployment target to v9 for XCode 12

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "CodableCSV",
     platforms: [
-        .macOS(.v10_10), .iOS(.v8), .tvOS(.v9), .watchOS(.v2)
+        .macOS(.v10_10), .iOS(.v9), .tvOS(.v9), .watchOS(.v2)
     ],
     products: [
         .library(name: "CodableCSV", targets: ["CodableCSV"]),


### PR DESCRIPTION
In XCode 12, this package generates this warning:

"The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 14.0.99."

## Description

Bumped minimum iOS deployment target to v9 for XCode 12

## Checklist

The following list must only be fulfilled by code-changing PRs. If you are making changes on the documentation, ignore these.

-   [x] Include in-code documentation at the top of the property/function/structure/class (if necessary).
-   [x] Merge to [`develop`](https://github.com/dehesa/CodableCSV/tree/develop).
-   [x] Add to existing tests or create new tests (if necessary).
