### PR TITLE
Numeric Bool

### DIFF
--- a/sources/declarative/decodable/DecoderConfiguration.swift
+++ b/sources/declarative/decodable/DecoderConfiguration.swift
@@ -65,6 +65,8 @@ extension Strategy {
         ///
         /// The value: `True`, `TRUE`, `TruE` or `YES`are accepted.
         case insensitive
+        /// Decodes the `Bool` from an underlying `0`/`1`
+        case numeric
         /// Decodes the `Bool` as a custom value decoded by the given closure.
         ///
         /// If the closure fails to decode a value from the given decoder, the error will be bubled up.

--- a/sources/declarative/decodable/containers/SingleValueDecodingContainer.swift
+++ b/sources/declarative/decodable/containers/SingleValueDecodingContainer.swift
@@ -74,6 +74,14 @@ extension ShadowDecoder.SingleValueContainer {
                 default: return nil
                 }
             }
+        case .numeric:
+            return try self._lowlevelDecode {
+                switch $0 {
+                case "1": return true
+                case "0": return false
+                default: return nil
+                }
+            }
         case .custom(let closure):
             return try closure(self._decoder)
         }

--- a/sources/declarative/encodable/EncoderConfiguration.swift
+++ b/sources/declarative/encodable/EncoderConfiguration.swift
@@ -58,6 +58,8 @@ extension Strategy {
     public enum BoolEncoding {
         /// Defers to `String`'s initializer.
         case deferredToString
+        /// Encode the `Bool` as `0` or `1`
+        case numeric
         /// Encode the `Bool` as a custom value encoded by the given closure.
         ///
         /// If the closure fails to encode a value into the given encoder, the error will be bubled up.

--- a/sources/declarative/encodable/containers/SingleValueEncodingContainer.swift
+++ b/sources/declarative/encodable/containers/SingleValueEncodingContainer.swift
@@ -59,6 +59,7 @@ extension ShadowEncoder.SingleValueContainer {
     mutating func encode(_ value: Bool) throws {
         switch self._encoder.sink._withUnsafeGuaranteedRef({ $0.configuration.boolStrategy }) {
         case .deferredToString: try self._lowlevelEncoding { String(value) }
+        case .numeric: try self._lowlevelEncoding { value ? "1" : "0" }
         case .custom(let closure): return try closure(value, self._encoder)
         }
     }

--- a/tests/CodableTests/CodableNumericBoolTests.swift
+++ b/tests/CodableTests/CodableNumericBoolTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+import CodableCSV
+
+/// Tests checking support for encoding/decoding numeric booleans.
+final class CodableNumericBoolTests: XCTestCase {
+    override func setUp() {
+        self.continueAfterFailure = false
+    }
+}
+
+extension CodableNumericBoolTests {
+    private struct _Object: Codable, Equatable {
+        var value1: Bool
+        var value2: Bool
+        var value3: Bool?
+    }
+    
+    private static let list: [_Object] = [
+        .init(value1: true, value2: false, value3: nil),
+        .init(value1: true, value2: true, value3: false),
+        .init(value1: false, value2: false, value3: true)
+    ]
+    
+    private static let csvOKHeader1 =
+        """
+        value1,value2,value3
+        1,0,
+        1,1,0
+        0,0,1
+
+        """
+    private static let csvOKHeader2 =
+        """
+        value3,value1,value2
+        ,1,0
+        0,1,1
+        1,0,0
+
+        """
+}
+
+extension CodableNumericBoolTests {
+    /// Test the regular numeric bool coding
+    func testRegularUsage() throws {
+        guard let data = Self.csvOKHeader1.data(using: .utf8) else {
+            fatalError()
+        }
+        let decoder = CSVDecoder {
+            $0.headerStrategy = .firstLine
+            $0.boolStrategy = .numeric
+        }
+        var result = try decoder.decode([_Object].self, from: data)
+        XCTAssertEqual(Self.list, result)
+        
+        guard let data2 = Self.csvOKHeader2.data(using: .utf8) else {
+            fatalError()
+        }
+
+        result = try decoder.decode([_Object].self, from: data2)
+        XCTAssertEqual(Self.list, result)
+        
+        let encoder = CSVEncoder {
+            $0.headers = ["value1", "value2", "value3"]
+            $0.boolStrategy = .numeric
+        }
+        
+        let csv = try encoder.encode(result, into: String.self)
+        XCTAssertEqual(Self.csvOKHeader1, csv)
+
+    }
+    
+    /// Test nil failure
+    func testThrows() throws {
+        // value2 = nil on 2nd row, must throw an exception
+        guard let data = """
+            value1,value2,value3
+            1,0,
+            1,,0
+            """.data(using: .utf8) else {
+            fatalError()
+        }
+        let decoder = CSVDecoder {
+            $0.headerStrategy = .firstLine
+            $0.boolStrategy = .numeric
+        }
+        XCTAssertThrowsError(try decoder.decode([_Object].self, from: data))
+    }
+    
+}
+


### PR DESCRIPTION
## Description

Bool values can be encoded as `0` or `1` in CSV files. Added support for this case.

## Checklist

The following list must only be fulfilled by code-changing PRs. If you are making changes on the documentation, ignore these.

-   [x] Include in-code documentation at the top of the property/function/structure/class (if necessary).
-   [x] Merge to [`develop`](https://github.com/dehesa/CodableCSV/tree/develop).
-   [x] Add to existing tests or create new tests (if necessary).
