### PR TITLE
Update README with CaseIterable tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,7 +574,7 @@ struct Student: Codable {
     var age: Int
     var hasPet: Bool
 
-    private CodingKeys: Int, CodingKey {
+    private enum CodingKeys: Int, CodingKey {
         case name = 0
         case age = 1
         case hasPet = 2
@@ -583,6 +583,31 @@ struct Student: Codable {
 ```
 
 > Using integer coding keys has the added benefit of better encoder/decoder performance. By explicitly indicating the field index, you let the decoder skip the functionality of matching coding keys string values to headers.
+
+To generate type-safe name header rows you can use an enum with `String` rawValues.
+
+```swift
+struct Student: Codable {
+    var name: String
+    var age: Int
+    var hasPet: Bool
+
+    private enum CodingKeys: String, CodingKey, CaseIterable {
+        case name = "name"
+        case age = "age"
+        case hasPet = "hasPet"
+    }
+}
+```
+
+Then configure your encoder with explicit headers.
+
+```swift
+let encoder = CSVEncoder {
+    $0.headers = Student.CodingKeys.allCases.map({ $0.rawValue })
+}
+```
+
 
 </p></details>
 <details><summary>A CSV is a long list of rows/records.</summary><p>


### PR DESCRIPTION
## Description

This adds an example to the README for using `CodingKeys` to generate header names. This is nice because if you add a new field to your struct you'll get a compile time error, but you still get string headers (unlike using Int-valued `CodingKeys`).

## Checklist

The following list must only be fulfilled by code-changing PRs. If you are making changes on the documentation, ignore these.

-   [n/a] Include in-code documentation at the top of the property/function/structure/class (if necessary).
-   [x] Merge to [`develop`](https://github.com/dehesa/CodableCSV/tree/develop).
-   [n/a] Add to existing tests or create new tests (if necessary).
