### PR TITLE
Handle both LF and CRLF by default

### DIFF
--- a/sources/Delimiter.swift
+++ b/sources/Delimiter.swift
@@ -1,9 +1,9 @@
 /// Separators scalars/strings.
 public enum Delimiter {
     /// The CSV pair of delimiters (field & row delimiters).
-    public typealias Pair = (field: Self.Field, row: Self.Row)
-    /// The CSV pair of delimiter in string format.
-    internal typealias RawPair = (field: [Unicode.Scalar], row: [Unicode.Scalar])
+    public typealias Pair = (field: Self.Field, row: Self.Row?)
+    /// The CSV pair of delimiter in string format. If row is nil, both LF and CRLF are considered valid row delimiters.
+    internal typealias RawPair = (field: [Unicode.Scalar], row: [Unicode.Scalar]?)
 }
 
 extension Delimiter {
@@ -59,3 +59,6 @@ extension Delimiter {
         }
     }
 }
+
+let newline = "\n".unicodeScalars
+let newlineArray = newline.map{ $0 }

--- a/sources/imperative/reader/ReaderConfiguration.swift
+++ b/sources/imperative/reader/ReaderConfiguration.swift
@@ -21,7 +21,7 @@ extension CSVReader {
         /// Designated initializer setting the default values.
         public init() {
             self.encoding = nil
-            self.delimiters = (field: ",", row: "\n")
+            self.delimiters = (field: ",", row: nil)
             self.escapingStrategy = .doubleQuote
             self.headerStrategy = .none
             self.trimStrategy = .init()

--- a/sources/imperative/writer/Writer.swift
+++ b/sources/imperative/writer/Writer.swift
@@ -137,7 +137,7 @@ extension CSVWriter {
             self.expectedFields = self.fieldIndex
         }
         // 4. Write the row delimiter.
-        try self._lowlevelWrite(delimiter: self.settings.delimiters.row)
+        try self._lowlevelWrite(delimiter: self.settings.delimiters.row ?? newlineArray)
         // 5. Increment the row index and reset the field index.
         (self.rowIndex, self.fieldIndex) = (self.rowIndex + 1, 0)
     }
@@ -169,7 +169,7 @@ extension CSVWriter {
             try self._lowlevelWrite(delimiter: f)
             try self._lowlevelWrite(field: "")
         }
-        try self._lowlevelWrite(delimiter: self.settings.delimiters.row)
+        try self._lowlevelWrite(delimiter: self.settings.delimiters.row ?? newlineArray)
         
         self.rowIndex += 1
         self.fieldIndex = 0

--- a/sources/imperative/writer/internal/WriterInference.swift
+++ b/sources/imperative/writer/internal/WriterInference.swift
@@ -11,10 +11,12 @@ internal extension CSVWriter {
     /// Creates a delimiter identifier closure.
     /// - parameter delimiter: Unicode scalars forming the field or row delimiters. The delimiter can have one or multiple unicode scalars.
     /// - returns: A function checking for `delimiter` on a given input and index.
-    static func makeMatcher(delimiter: [Unicode.Scalar]) -> DelimiterChecker  {
+    static func makeMatcher(delimiter _delimiter: [Unicode.Scalar]?) -> DelimiterChecker  {
+        let delimiter = _delimiter ?? newlineArray
+
         // This should never be triggered.
         precondition(!delimiter.isEmpty, "Delimiters must include at least one unicode scalar.")
-        
+
         // For optimization sake, a _delimiter checker_ is built for a unique single unicode scalar.
         if delimiter.count == 1 {
             let scalar = delimiter.first!

--- a/sources/imperative/writer/internal/WriterInternals.swift
+++ b/sources/imperative/writer/internal/WriterInternals.swift
@@ -42,7 +42,7 @@ internal extension CSVWriter {
         /// - throws: `CSVError<CSVWriter>` exclusively.
         init(configuration: CSVWriter.Configuration, encoding: String.Encoding) throws {
             // 1. Validate the delimiters.
-            let (field, row) = (configuration.delimiters.field.rawValue, configuration.delimiters.row.rawValue)
+            let (field, row) = (configuration.delimiters.field.rawValue, configuration.delimiters.row?.rawValue ?? newline)
             if field.isEmpty || row.isEmpty {
                 throw Error._invalidEmptyDelimiter()
             } else if field.elementsEqual(row) {

--- a/tests/declarative/DecodingBadInputTests.swift
+++ b/tests/declarative/DecodingBadInputTests.swift
@@ -52,3 +52,46 @@ extension DecodingBadInputTests {
         XCTAssertNoThrow(try decoder.decode([_Row].self, from: input))
     }
 }
+
+extension DecodingBadInputTests {
+    /// Tests CRLF delimiters with escape fields.
+    func testInputCRLF() throws {
+        let input = "Name\r\n\"G\"\r\n"
+
+        let decoder = CSVDecoder {
+            $0.encoding = .utf8
+            $0.bufferingStrategy = .sequential
+            $0.headerStrategy = .firstLine
+            $0.trimStrategy = .whitespaces
+            $0.delimiters.row = nil
+        }
+        do {
+            let file = try decoder.decode([String].self, from: input)
+            for row in file { print(row) }
+        } catch {
+            print(error)
+            throw error
+        }
+    }
+
+    /// Tests CRLF delimiters with escape fields.
+    func testInputLF() throws {
+        let input = "Name\n\"G\"\n"
+
+        let decoder = CSVDecoder {
+            $0.encoding = .utf8
+            $0.bufferingStrategy = .sequential
+            $0.headerStrategy = .firstLine
+            $0.trimStrategy = .whitespaces
+            $0.delimiters.row = nil
+        }
+        do {
+            let file = try decoder.decode([String].self, from: input)
+            for row in file { print(row) }
+        } catch {
+            print(error)
+            throw error
+        }
+    }
+
+}

--- a/tests/declarative/DecodingRegularUsageTests.swift
+++ b/tests/declarative/DecodingRegularUsageTests.swift
@@ -27,7 +27,7 @@ extension DecodingRegularUsageTests {
         /// - parameter delimiters: Unicode scalars to use to mark fields and rows.
         /// - returns: Swift String representing the CSV file.
         static func toCSV(_ sample: [[String]], delimiters: Delimiter.Pair) -> String {
-            let (f, r) = (String(delimiters.field.rawValue), String(delimiters.row.rawValue))
+            let (f, r) = (String(delimiters.field.rawValue), String(delimiters.row?.rawValue ?? newline))
             return sample.map { $0.joined(separator: f) }.joined(separator: r).appending(r)
         }
     }

--- a/tests/declarative/DecodingWrappersTests.swift
+++ b/tests/declarative/DecodingWrappersTests.swift
@@ -37,7 +37,7 @@ extension DecodingWrappersTests {
         /// - parameter delimiters: Unicode scalars to use to mark fields and rows.
         /// - returns: Swift String representing the CSV file.
         static func toCSV(_ sample: [[String]], delimiters: Delimiter.Pair) -> String {
-            let (f, r) = (String(delimiters.field.rawValue), String(delimiters.row.rawValue))
+            let (f, r) = (String(delimiters.field.rawValue), String(delimiters.row?.rawValue ?? newline))
             return sample.map { $0.joined(separator: f) }.joined(separator: r).appending(r)
         }
     }

--- a/tests/declarative/EncodingLazyTests.swift
+++ b/tests/declarative/EncodingLazyTests.swift
@@ -79,7 +79,7 @@ extension EncodingLazyTests {
             let lazyEncoder = try CSVEncoder(configuration: configuration).lazy(into: String.self)
             try lazyEncoder.encodeRow(value)
             let string = try lazyEncoder.endEncoding()
-            XCTAssertEqual(string, "\(delimiters.row.rawValue)")
+            XCTAssertEqual(string, "\(delimiters.row?.rawValue ?? newline)")
         }
     }
     
@@ -105,7 +105,7 @@ extension EncodingLazyTests {
             let lazyEncoder = try CSVEncoder(configuration: configuration).lazy(into: String.self)
             try lazyEncoder.encodeRow(student)
             let string = try lazyEncoder.endEncoding()
-            let content = string.split(separator: .init(delimiters.row.rawValue.first!))
+            let content = string.split(separator: .init((delimiters.row?.rawValue ?? newline).first!))
 
             let encodedHeaders = content[0].split(separator: Character(delimiters.field.rawValue.first!)).map { String($0) }
             XCTAssertEqual(headers, encodedHeaders)
@@ -140,7 +140,7 @@ extension EncodingLazyTests {
             let lazyEncoder = try CSVEncoder(configuration: configuration).lazy(into: String.self)
             try lazyEncoder.encodeRow(student)
             let string = try lazyEncoder.endEncoding()
-            let content = string.split(separator: .init(delimiters.row.rawValue.first!))
+            let content = string.split(separator: .init((delimiters.row?.rawValue ?? newline).first!))
             
             let encodedValues = content[0].split(separator: Character(delimiters.field.rawValue.first!)).map { String($0) }
             XCTAssertEqual(student.name, encodedValues[0])
@@ -182,7 +182,7 @@ extension EncodingLazyTests {
             }
             
             let string = try lazyEncoder.endEncoding()
-            let content = string.split(separator: Character(delimiters.row.rawValue.first!)).map { String($0) }
+            let content = string.split(separator: Character((delimiters.row?.rawValue ?? newline).first!)).map { String($0) }
             XCTAssertEqual(content.count, 1+students.count)
             XCTAssertEqual(content[0], headers.joined(separator: String(delimiters.field.rawValue)))
         }
@@ -222,7 +222,7 @@ extension EncodingLazyTests {
                 let string = try lazyEncoder.endEncoding()
                 XCTAssertFalse(string.isEmpty)
 
-                let content = string.split(separator: Character(delimiters.row.rawValue.first!)).map { String($0) }
+                let content = string.split(separator: Character((delimiters.row?.rawValue ?? newline).first!)).map { String($0) }
                 if h.isEmpty {
                     XCTAssertEqual(content.count, students.count)
                 } else {

--- a/tests/declarative/EncodingRegularUsageTests.swift
+++ b/tests/declarative/EncodingRegularUsageTests.swift
@@ -118,7 +118,7 @@ extension EncodingRegularUsageTests {
             let encoder = CSVEncoder(configuration: configuration)
             let data = try encoder.encode(value, into: Data.self)
             let string = String(data: data, encoding: encoding)!
-            XCTAssertEqual(string, "\(delimiters.row.rawValue)")
+            XCTAssertEqual(string, "\(delimiters.row?.rawValue ?? newline)")
         }
     }
     
@@ -167,7 +167,7 @@ extension EncodingRegularUsageTests {
             
             let encoder = CSVEncoder(configuration: configuration)
             let string = try encoder.encode(school, into: String.self)
-            let content = string.split(separator: .init(delimiters.row.rawValue.first!))
+            let content = string.split(separator: .init((delimiters.row?.rawValue ?? newline).first!))
             
             let encodedHeaders = content[0].split(separator: Character(delimiters.field.rawValue.first!)).map { String($0) }
             XCTAssertEqual(headers, encodedHeaders)
@@ -202,7 +202,7 @@ extension EncodingRegularUsageTests {
             
             let encoder = CSVEncoder(configuration: configuration)
             let string = try encoder.encode(school, into: String.self)
-            let content = string.split(separator: .init(delimiters.row.rawValue.first!))
+            let content = string.split(separator: .init((delimiters.row?.rawValue ?? newline).first!))
 
             let encodedValues = content[0].split(separator: Character(delimiters.field.rawValue.first!)).map { String($0) }
             XCTAssertEqual(student.name, encodedValues[0])
@@ -240,7 +240,7 @@ extension EncodingRegularUsageTests {
             encoder.headers = headers
             
             let string = try encoder.encode(school, into: String.self)
-            let content = string.split(separator: Character(delimiters.row.rawValue.first!)).map { String($0) }
+            let content = string.split(separator: Character((delimiters.row?.rawValue ?? newline).first!)).map { String($0) }
             XCTAssertEqual(content.count, 1+student.count)
             XCTAssertEqual(content[0], headers.joined(separator: String(delimiters.field.rawValue)))
         }
@@ -277,7 +277,7 @@ extension EncodingRegularUsageTests {
                 let string = try encoder.encode(school, into: String.self)
                 XCTAssertFalse(string.isEmpty)
                 
-                let content = string.split(separator: Character(delimiters.row.rawValue.first!)).map { String($0) }
+                let content = string.split(separator: Character((delimiters.row?.rawValue ?? newline).first!)).map { String($0) }
                 if h.isEmpty {
                     XCTAssertEqual(content.count, student.count)
                 } else {
@@ -318,7 +318,7 @@ extension EncodingRegularUsageTests {
                 let string = try encoder.encode(school, into: String.self)
                 XCTAssertFalse(string.isEmpty)
 
-                let content = string.split(separator: Character(delimiters.row.rawValue.first!)).map { String($0) }
+                let content = string.split(separator: Character((delimiters.row?.rawValue ?? newline).first!)).map { String($0) }
                 if h.isEmpty {
                     XCTAssertEqual(content.count, school.lastIndex+1)
                 } else {

--- a/tests/imperative/ReaderCollectionsTests.swift
+++ b/tests/imperative/ReaderCollectionsTests.swift
@@ -8,6 +8,8 @@ final class ReaderCollectionsTests: XCTestCase {
     }
 }
 
+let newline = "\n".unicodeScalars
+
 extension ReaderCollectionsTests {
     /// The test data used for this file.
     private enum _TestData {
@@ -28,7 +30,7 @@ extension ReaderCollectionsTests {
         /// - parameter delimiters: Unicode scalars to use to mark fields and rows.
         /// - returns: Swift String representing the CSV file.
         static func toCSV(_ sample: [[String]], delimiters: Delimiter.Pair) -> String {
-            let (f, r) = (String(delimiters.field.rawValue), String(delimiters.row.rawValue))
+            let (f, r) = (String(delimiters.field.rawValue), String(delimiters.row?.rawValue ?? newline))
             return sample.map { $0.joined(separator: f) }.joined(separator: r).appending(r)
         }
     }

--- a/tests/imperative/ReaderTests.swift
+++ b/tests/imperative/ReaderTests.swift
@@ -42,7 +42,7 @@ extension ReaderTests {
         /// - parameter delimiters: Unicode scalars to use to mark fields and rows.
         /// - returns: Swift String representing the CSV file.
         static func toCSV(_ sample: [[String]], delimiters: Delimiter.Pair) -> String {
-            let (f, r) = (String(delimiters.field.rawValue), String(delimiters.row.rawValue))
+            let (f, r) = (String(delimiters.field.rawValue), String(delimiters.row?.rawValue ?? newline))
             return sample.map { $0.joined(separator: f) }.joined(separator: r).appending(r)
         }
         /// Generates a URL pointing to a temporary file on the system temporary folder.

--- a/tests/imperative/WriterTests.swift
+++ b/tests/imperative/WriterTests.swift
@@ -23,7 +23,7 @@ extension WriterTests {
         /// - parameter delimiters: Unicode scalars to use to mark fields and rows.
         /// - returns: Swift String representing the CSV file.
         static func toCSV(_ sample: [[String]], delimiters: Delimiter.Pair) -> String {
-            let (f, r) = (String(delimiters.field.rawValue), String(delimiters.row.rawValue))
+            let (f, r) = (String(delimiters.field.rawValue), String(delimiters.row?.rawValue ?? newline))
             return sample.map { $0.joined(separator: f) }.joined(separator: r).appending(r)
         }
         /// Generates a URL pointing to a temporary file on the system temporary folder.
@@ -62,14 +62,14 @@ extension WriterTests {
         let field = "Marine-Anaïs"
         // 1. Tests the full-file string decoder.
         let string = try CSVWriter.encode(rows: [[field]], into: String.self, configuration: config)
-        XCTAssertEqual(string, field + String(config.delimiters.row.rawValue))
+        XCTAssertEqual(string, field + String(config.delimiters.row?.rawValue ?? newline))
         // 2. Tests the full-file data decoder.
         let data = try CSVWriter.encode(rows: [[field]], into: Data.self, configuration: config)
-        XCTAssertEqual(String(data: data, encoding: .utf8)!, field + String(config.delimiters.row.rawValue))
+        XCTAssertEqual(String(data: data, encoding: .utf8)!, field + String(config.delimiters.row?.rawValue ?? newline))
         // 3. Tests the full-file decoder.
         let url = _TestData.generateTemporaryFileURL()
         try CSVWriter.encode(rows: [[field]], into: url, configuration: config)
-        XCTAssertEqual(String(data: try Data(contentsOf: url), encoding: .utf8)!, field + String(config.delimiters.row.rawValue))
+        XCTAssertEqual(String(data: try Data(contentsOf: url), encoding: .utf8)!, field + String(config.delimiters.row?.rawValue ?? newline))
         try FileManager.default.removeItem(at: url)
         // 4. Tests the line reader.
         let writer = try CSVWriter()


### PR DESCRIPTION
## Description

If `$0.delimiters.row` is not specified in the configuration, handle both LF and CRLF as possible row delimiters.

The main change is a function returned from `CSVReader.makeMatcher` when the delimiter row is nil. This function explicitly accepts either `\n` or `\r\n`.  All other changes are incidental to making Delimiter.Row an optional.

This is more of a proof of concept, there are multiple approaches to take towards this, I'm not sure what fits best with the design of this library.

Addresses #35

## Checklist

The following list must only be fulfilled by code-changing PRs. If you are making changes on the documentation, ignore these.

-   [x] Include in-code documentation at the top of the property/function/structure/class (if necessary).
-   [ ] Merge to [`develop`](https://github.com/dehesa/CodableCSV/tree/develop).
-   [x] Add to existing tests or create new tests (if necessary).
