### PR TITLE
Add line offset headers

### DIFF
--- a/sources/imperative/reader/Reader.swift
+++ b/sources/imperative/reader/Reader.swift
@@ -60,7 +60,7 @@ public final class CSVReader: IteratorProtocol, Sequence {
       guard let headers = try self._parseLine(rowIndex: 0) else { self.status = .finished; return }
       guard !headers.isEmpty else { throw Error._invalidEmptyHeader() }
       self.headers = headers
-      self.count = (rows: 0, fields: headers.count)
+      self.count = (rows: 1, fields: headers.count)
 //    case .unknown: #warning("TODO")
     }
   }

--- a/sources/imperative/reader/Reader.swift
+++ b/sources/imperative/reader/Reader.swift
@@ -53,14 +53,14 @@ public final class CSVReader: IteratorProtocol, Sequence {
       self.headers = headers
       self.count = (rows: 1, fields: headers.count)
     case let .lineNumber(index):
-        // Parse rows, but ignore them
-        for _ in 0..<index {
-            _ = try self._parseLine(rowIndex: 0)
-        }
-        guard let headers = try self._parseLine(rowIndex: index) else { self.status = .finished; return }
-        guard !headers.isEmpty else { throw Error._invalidEmptyHeader() }
-        self.headers = headers
-        self.count = (rows: index, fields: headers.count)
+      // Parse rows, but ignore them
+      for _ in 0..<index {
+        _ = try self._parseLine(rowIndex: 0)
+      }
+      guard let headers = try self._parseLine(rowIndex: 0) else { self.status = .finished; return }
+      guard !headers.isEmpty else { throw Error._invalidEmptyHeader() }
+      self.headers = headers
+      self.count = (rows: 0, fields: headers.count)
 //    case .unknown: #warning("TODO")
     }
   }

--- a/sources/imperative/reader/ReaderConfiguration.swift
+++ b/sources/imperative/reader/ReaderConfiguration.swift
@@ -31,7 +31,7 @@ extension CSVReader {
 }
 
 extension Strategy {
-    /// Indication on whether the CSV file contains headers or not.
+  /// Indication on whether the CSV file contains headers or not.
   public enum Header: ExpressibleByNilLiteral, ExpressibleByBooleanLiteral {
     /// The CSV contains no header row.
     case none

--- a/sources/imperative/reader/ReaderConfiguration.swift
+++ b/sources/imperative/reader/ReaderConfiguration.swift
@@ -31,12 +31,14 @@ extension CSVReader {
 }
 
 extension Strategy {
-  /// Indication on whether the CSV file contains headers or not.
+    /// Indication on whether the CSV file contains headers or not.
   public enum Header: ExpressibleByNilLiteral, ExpressibleByBooleanLiteral {
     /// The CSV contains no header row.
     case none
     /// The CSV contains a single header row.
     case firstLine
+    /// The CSV contains a single header row at the specified row index.
+    case lineNumber(index: Int)
 //    /// It is not known whether the CSV contains a header row. The library will try to infer it!
 //    case unknown
 

--- a/sources/imperative/reader/internal/ReaderInternals.swift
+++ b/sources/imperative/reader/internal/ReaderInternals.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 extension CSVReader: Failable {
-  /// Reader status indicating whether there are remaning lines to read, the CSV has been completely parsed, or an error occurred and no further operation shall be performed.
+  /// Reader status indicating whether there are remaining lines to read, the CSV has been completely parsed, or an error occurred and no further operation shall be performed.
   public enum Status {
     /// The CSV file hasn't been completely parsed.
     case active
@@ -17,7 +17,7 @@ extension CSVReader: Failable {
     case invalidConfiguration = 1
     /// The CSV data is invalid.
     case invalidInput = 2
-//    /// The inferral process to figure out delimiters or header row status was unsuccessful.
+//    /// The inferal process to figure out delimiters or header row status was unsuccessful.
 //    case inferenceFailure = 3
     /// The input stream failed.
     case streamFailure = 4
@@ -49,7 +49,7 @@ extension CSVReader {
     /// Optimization constant used to overcome ObjC overhead.
     let isTrimNeeded: Bool
 
-    /// Creates the inmutable reader settings from the user provided configuration values.
+    /// Creates the immutable reader settings from the user provided configuration values.
     /// - parameter configuration: The configuration values provided by the API user.
     /// - parameter decoder: The instance providing the input `Unicode.Scalar`s.
     /// - parameter buffer: Small buffer use to store `Unicode.Scalar` values that have been read from the input, but haven't yet been processed.


### PR DESCRIPTION
Useful for skipping rows in CSVs that have table titles

## Description

This PR adds a header strategy to parse headers from the specified row number, ignoring any previous row (and fixes a few typos). The change is additive, leaving the existing `.firstLine` option in place. I've been using the the header strategy in of of my own apps without any issues. 

The tests have been updated to include the new strategy by way of a table title, and all pass. 

## Checklist

The following list must only be fulfilled by code-changing PRs. If you are making changes on the documentation, ignore these.

-   [x] Include in-code documentation at the top of the property/function/structure/class (if necessary).
-   [x] Merge to [`develop`](https://github.com/dehesa/CodableCSV/tree/develop).
-   [x] Add to existing tests or create new tests (if necessary).
