### PR TITLE
Added new writer configuration option 'quoteAll'

### DIFF
--- a/sources/imperative/writer/Writer.swift
+++ b/sources/imperative/writer/Writer.swift
@@ -200,7 +200,7 @@ extension CSVWriter {
 
     // 3.A. If escaping is allowed.
     if let escapingScalar = self.settings.escapingScalar {
-      var (index, needsEscaping) = (0, false)
+      var (index, needsEscaping) = (0, self.settings.quoteAll)
       // 4. Iterate through all the input's Unicode scalars.
       while index < input.endIndex {
         let scalar = input[index]

--- a/sources/imperative/writer/WriterConfiguration.swift
+++ b/sources/imperative/writer/WriterConfiguration.swift
@@ -13,6 +13,8 @@ extension CSVWriter {
     public var delimiters: Delimiter.Pair
     /// The strategy to allow/disable escaped fields and how.
     public var escapingStrategy: Strategy.Escaping
+    /// Whether to quote all fields (as opposed to quoting only fields that need to be escaped)
+    public var quoteAll: Bool
     /// The row of headers to write at the beginning of the CSV data.
     ///
     /// If empty, no row will be written.
@@ -25,6 +27,7 @@ extension CSVWriter {
       self.delimiters = (field: ",", row: "\n")
       self.escapingStrategy = .doubleQuote
       self.headers = Array()
+      self.quoteAll = false
     }
   }
 }

--- a/sources/imperative/writer/internal/WriterInternals.swift
+++ b/sources/imperative/writer/internal/WriterInternals.swift
@@ -32,6 +32,8 @@ extension CSVWriter {
     let delimiters: (field: [Unicode.Scalar], row: [Unicode.Scalar])
     /// The unicode scalar used as encapsulator and escaping character (when printed two times).
     let escapingScalar: Unicode.Scalar?
+    /// Whether to quote all fields (as opposed to quoting only fields that need to be escaped)
+    let quoteAll: Bool
     /// Boolean indicating whether the received CSV contains a header row or not.
     let headers: [String]
     /// The encoding used to identify the underlying data.
@@ -52,6 +54,7 @@ extension CSVWriter {
       }!)
       // 2. Copy all other values.
       self.escapingScalar = configuration.escapingStrategy.scalar
+      self.quoteAll = configuration.quoteAll
       self.headers = configuration.headers
       self.encoding = encoding
     }

--- a/tests/declarative/CodableNumericBoolTests.swift
+++ b/tests/declarative/CodableNumericBoolTests.swift
@@ -52,6 +52,26 @@ extension CodableNumericBoolTests {
     XCTAssertEqual(rows, try decoder.decode([_Row].self, from: shuffledString.data(using: .utf8)!))
   }
 
+  /// Tests the quoteAll configuration option
+  func testQuoteAll() throws {
+    let rows = [_Row(a: true,  b: false, c: nil),
+                _Row(a: true,  b: true,  c: false),
+                _Row(a: false, b: false, c: true)]
+    let string = """
+            "a","b","c"
+            "1","0",
+            "1","1","0"
+            "0","0","1"
+            """.appending("\n")
+
+    let encoder = CSVEncoder {
+      $0.headers = ["a", "b", "c"]
+      $0.boolStrategy = .numeric
+      $0.quoteAll = true
+    }
+    XCTAssertEqual(string, try encoder.encode(rows, into: String.self))
+  }
+
   /// Tests the error throwing/handling.
   func testThrows() throws {
     // b = nil on 2nd row, must throw an exception.


### PR DESCRIPTION
Introduces a new encoder option.

## Description
Example:

    let encoder = CSVEncoder {
      // ...
      $0.quoteAll = true
    }

The effect is that each field is quoted in the output regardless of whether it needs to be escaped. This may be useful for round-trip testing where the input file contains redundant quotation marks.
 
## Checklist

The following list must only be fulfilled by code-changing PRs. If you are making changes on the documentation, ignore these.

-   [x] Include in-code documentation at the top of the property/function/structure/class (if necessary).
-   [x] Merge to [`develop`](https://github.com/dehesa/CodableCSV/tree/develop).
-   [x] Add to existing tests or create new tests (if necessary).
