### PR TITLE
Fix Swift 5.7 warnings.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,10 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.9
 import PackageDescription
 
 let package = Package(
   name: "CodableCSV",
   platforms: [
-    .macOS(.v10_10), .iOS(.v11), .tvOS(.v9), .watchOS(.v2)
+    .macOS(.v14), .iOS(.v17), .tvOS(.v17), .watchOS(.v10)
   ],
   products: [
     .library(name: "CodableCSV", targets: ["CodableCSV"]),

--- a/sources/Error.swift
+++ b/sources/Error.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Errors that can be thrown from a CSV reader instance.
-public final class CSVError<F>: LocalizedError, CustomNSError, CustomDebugStringConvertible where F:Failable {
+public final class CSVError<F>: LocalizedError, CustomNSError, CustomDebugStringConvertible, @unchecked Sendable where F:Failable {
   /// The type of error being raised.
   public let type: F.Failure
   /// A localized message describing the reason for the failure.

--- a/sources/declarative/decodable/Decoder.swift
+++ b/sources/declarative/decodable/Decoder.swift
@@ -34,7 +34,7 @@ extension CSVDecoder {
   /// Returns a value of the type you specify, decoded from a CSV file (given as a `Data` blob).
   /// - parameter type: The type of the value to decode from the supplied file.
   /// - parameter data: The data blob representing a CSV file.
-  open func decode<T:Decodable>(_ type: T.Type, from data: Data) throws -> T {
+  public func decode<T:Decodable>(_ type: T.Type, from data: Data) throws -> T {
     let reader = try CSVReader(input: data, configuration: self._configuration.readerConfiguration)
     return try withExtendedLifetime(ShadowDecoder.Source(reader: reader, configuration: self._configuration, userInfo: self.userInfo)) {
       try T(from: ShadowDecoder(source: .passUnretained($0), codingPath: []))
@@ -44,7 +44,7 @@ extension CSVDecoder {
   /// Returns a value of the type you specify, decoded from a CSV file (given as a `String`).
   /// - parameter type: The type of the value to decode from the supplied file.
   /// - parameter string: A Swift string representing a CSV file.
-  open func decode<T:Decodable>(_ type: T.Type, from string: String) throws -> T {
+  public func decode<T:Decodable>(_ type: T.Type, from string: String) throws -> T {
     let reader = try CSVReader(input: string, configuration: self._configuration.readerConfiguration)
     return try withExtendedLifetime(ShadowDecoder.Source(reader: reader, configuration: self._configuration, userInfo: self.userInfo)) {
       try T(from: ShadowDecoder(source: .passUnretained($0), codingPath: []))
@@ -54,7 +54,7 @@ extension CSVDecoder {
   /// Returns a value of the type you specify, decoded from a CSV file (being pointed by the url).
   /// - parameter type: The type of the value to decode from the supplied file.
   /// - parameter url: The URL pointing to the file to decode.
-  open func decode<T:Decodable>(_ type: T.Type, from url: URL) throws -> T {
+  public func decode<T:Decodable>(_ type: T.Type, from url: URL) throws -> T {
     let reader = try CSVReader(input: url, configuration: self._configuration.readerConfiguration)
     return try withExtendedLifetime(ShadowDecoder.Source(reader: reader, configuration: self._configuration, userInfo: self.userInfo)) {
       try T(from: ShadowDecoder(source: .passUnretained($0), codingPath: []))
@@ -64,7 +64,7 @@ extension CSVDecoder {
   /// Returns a value of the type you specify, decoded from a CSV file (provided by the input stream).
   /// - parameter type: The type of the value to decode from the supplied file.
   /// - parameter stream: The input stream providing the raw bytes.
-  open func decode<T:Decodable>(_ type: T.Type, from stream: InputStream) throws -> T {
+  public func decode<T:Decodable>(_ type: T.Type, from stream: InputStream) throws -> T {
     let reader = try CSVReader(input: stream, configuration: self._configuration.readerConfiguration)
     return try withExtendedLifetime(ShadowDecoder.Source(reader: reader, configuration: self._configuration, userInfo: self.userInfo)) {
       try T(from: ShadowDecoder(source: .passUnretained($0), codingPath: []))
@@ -76,7 +76,7 @@ extension CSVDecoder {
   /// Returns a sequence for decoding row-by-row from a CSV file (given as a `Data` blob).
   /// - parameter data: The data blob representing a CSV file.
   /// - throws: `CSVError<CSVReader>` exclusively.
-  open func lazy(from data: Data) throws -> Lazy {
+  public func lazy(from data: Data) throws -> Lazy {
     let reader = try CSVReader(input: data, configuration: self._configuration.readerConfiguration)
     let source = ShadowDecoder.Source(reader: reader, configuration: self._configuration, userInfo: self.userInfo)
     return Lazy(source: source)
@@ -85,7 +85,7 @@ extension CSVDecoder {
   /// Returns a sequence for decoding row-by-row from a CSV file (given as a `String`).
   /// - parameter string: A Swift string representing a CSV file.
   /// - throws: `CSVError<CSVReader>` exclusively.
-  open func lazy(from string: String) throws -> Lazy {
+  public func lazy(from string: String) throws -> Lazy {
     let reader = try CSVReader(input: string, configuration: self._configuration.readerConfiguration)
     let source = ShadowDecoder.Source(reader: reader, configuration: self._configuration, userInfo: self.userInfo)
     return Lazy(source: source)
@@ -94,7 +94,7 @@ extension CSVDecoder {
   /// Returns a sequence for decoding row-by-row from a CSV file (being pointed by `url`).
   /// - parameter url: The URL pointing to the file to decode.
   /// - throws: `CSVError<CSVReader>` exclusively.
-  open func lazy(from url: URL) throws -> Lazy {
+  public func lazy(from url: URL) throws -> Lazy {
     let reader = try CSVReader(input: url, configuration: self._configuration.readerConfiguration)
     let source = ShadowDecoder.Source(reader: reader, configuration: self._configuration, userInfo: self.userInfo)
     return Lazy(source: source)

--- a/sources/declarative/encodable/Encoder.swift
+++ b/sources/declarative/encodable/Encoder.swift
@@ -35,7 +35,7 @@ extension CSVEncoder {
   /// - parameter value: The value to encode as CSV.
   /// - parameter type: The Swift type for a data blob.
   /// - returns: `Data` blob with the CSV representation of `value`.
-  open func encode<T:Encodable>(_ value: T, into type: Data.Type) throws -> Data {
+  public func encode<T:Encodable>(_ value: T, into type: Data.Type) throws -> Data {
     let writer = try CSVWriter(configuration: self._configuration.writerConfiguration)
     try withExtendedLifetime(try ShadowEncoder.Sink(writer: writer, configuration: self._configuration, userInfo: self.userInfo)) {
       try value.encode(to: ShadowEncoder(sink: .passUnretained($0), codingPath: []))
@@ -48,7 +48,7 @@ extension CSVEncoder {
   /// - parameter value: The value to encode as CSV.
   /// - parameter type: The Swift type for a string.
   /// - returns: `String` with the CSV representation of `value`.
-  open func encode<T:Encodable>(_ value: T, into type: String.Type) throws -> String {
+  public func encode<T:Encodable>(_ value: T, into type: String.Type) throws -> String {
     let data = try self.encode(value, into: Data.self)
     let encoding = self._configuration.writerConfiguration.encoding ?? .utf8
     return String(data: data, encoding: encoding)!
@@ -58,7 +58,7 @@ extension CSVEncoder {
   /// - parameter value: The value to encode as CSV.
   /// - parameter fileURL: The file receiving the encoded values.
   /// - parameter append: In case an existing file is under the given URL, this Boolean indicates that the information will be appended to the file (`true`), or the file will be overwritten (`false`).
-  open func encode<T:Encodable>(_ value: T, into fileURL: URL, append: Bool = false) throws {
+  public func encode<T:Encodable>(_ value: T, into fileURL: URL, append: Bool = false) throws {
     let writer = try CSVWriter(fileURL: fileURL, append: append, configuration: self._configuration.writerConfiguration)
     try withExtendedLifetime(try ShadowEncoder.Sink(writer: writer, configuration: self._configuration, userInfo: self.userInfo)) {
       try value.encode(to: ShadowEncoder(sink: .passUnretained($0), codingPath: []))
@@ -71,7 +71,7 @@ extension CSVEncoder {
   /// Returns an instance to encode row-by-row the feeded values.
   /// - parameter type: The Swift type for a data blob.
   /// - returns: Instance used for _on demand_ encoding.
-  open func lazy(into type: Data.Type) throws -> Lazy<Data> {
+  public func lazy(into type: Data.Type) throws -> Lazy<Data> {
     let writer = try CSVWriter(configuration: self._configuration.writerConfiguration)
     let sink = try ShadowEncoder.Sink(writer: writer, configuration: self._configuration, userInfo: self.userInfo)
     return Lazy<Data>(sink: sink)
@@ -80,7 +80,7 @@ extension CSVEncoder {
   /// Returns an instance to encode row-by-row the feeded values.
   /// - parameter type: The Swift type for a data blob.
   /// - returns: Instance used for _on demand_ encoding.
-  open func lazy(into type: String.Type) throws -> Lazy<String> {
+  public func lazy(into type: String.Type) throws -> Lazy<String> {
     let writer = try CSVWriter(configuration: self._configuration.writerConfiguration)
     let sink = try ShadowEncoder.Sink(writer: writer, configuration: self._configuration, userInfo: self.userInfo)
     return Lazy<String>(sink: sink)
@@ -90,7 +90,7 @@ extension CSVEncoder {
   /// - parameter fileURL: The file receiving the encoded values.
   /// - parameter append: In case an existing file is under the given URL, this Boolean indicates that the information will be appended to the file (`true`), or the file will be overwritten (`false`).
   /// - returns: Instance used for _on demand_ encoding.
-  open func lazy(into fileURL: URL, append: Bool = false) throws -> Lazy<URL> {
+  public func lazy(into fileURL: URL, append: Bool = false) throws -> Lazy<URL> {
     let writer = try CSVWriter(fileURL: fileURL, append: append, configuration: self._configuration.writerConfiguration)
     let sink = try ShadowEncoder.Sink(writer: writer, configuration: self._configuration, userInfo: self.userInfo)
     return Lazy<URL>(sink: sink)

--- a/sources/declarative/encodable/containers/SingleValueEncodingContainer.swift
+++ b/sources/declarative/encodable/containers/SingleValueEncodingContainer.swift
@@ -191,8 +191,8 @@ extension ShadowEncoder.SingleValueContainer {
   mutating func encode(_ value: Decimal) throws {
     switch self._encoder.sink._withUnsafeGuaranteedRef({ $0.configuration.decimalStrategy }) {
     case .locale(let locale):
-      var number = value
-      let string = NSDecimalString(&number, locale)
+      let style = Decimal.FormatStyle(locale: locale ?? Locale.current)
+      let string = String(value.formatted(style))
       try self.encode(string)
     case .custom(let closure):
       try closure(value, self._encoder)

--- a/sources/imperative/writer/WriterConfiguration.swift
+++ b/sources/imperative/writer/WriterConfiguration.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 extension CSVWriter {
   /// Configuration for how to write CSV data.
   public struct Configuration {


### PR DESCRIPTION
The following warning is emitted for a number of function declarations when compiling with Swift 5.7 (Xcode 14 Beta):
*"Non-'@objc' instance method in extensions cannot be overridden; use 'public' instead"*

Changing the access levels of the functions from *open* to *public* resolves the warnings.