### PR TITLE
Update default row delimiter for CSVReader

### DIFF
--- a/sources/imperative/reader/ReaderConfiguration.swift
+++ b/sources/imperative/reader/ReaderConfiguration.swift
@@ -21,7 +21,7 @@ extension CSVReader {
     /// Designated initializer setting the default values.
     public init() {
       self.encoding = nil
-      self.delimiters = (field: ",", row: "\n")
+      self.delimiters = (field: ",", row: .standard)
       self.escapingStrategy = .doubleQuote
       self.headerStrategy = .none
       self.trimStrategy = CharacterSet()


### PR DESCRIPTION
Change default row delimiter to `.standard` to avoid additional `\r` in some fields

## Description

In some cases, new line are represented as `\r\n` and in some cases, `\n`. This behavior is different on different OSs and even different apps.

The built-in `.standard` is a better solution to handle this. In this way, we can more accurately get every field.

## Checklist

The following list must only be fulfilled by code-changing PRs. If you are making changes on the documentation, ignore these.

-   [x] Include in-code documentation at the top of the property/function/structure/class (if necessary).
-   [x] Merge to [`develop`](https://github.com/dehesa/CodableCSV/tree/develop).
-   [x] Add to existing tests or create new tests (if necessary).
