### PR TITLE
- added some woraround code to see if can compile on XCode 16

### DIFF
--- a/sources/declarative/encodable/containers/SingleValueEncodingContainer.swift
+++ b/sources/declarative/encodable/containers/SingleValueEncodingContainer.swift
@@ -191,8 +191,17 @@ extension ShadowEncoder.SingleValueContainer {
   mutating func encode(_ value: Decimal) throws {
     switch self._encoder.sink._withUnsafeGuaranteedRef({ $0.configuration.decimalStrategy }) {
     case .locale(let locale):
-      var number = value
-      let string = NSDecimalString(&number, locale)
+            // original code that falied with XCdoe 16 compiler
+      //var number = value
+      //let string = NSDecimalString(&number, locale)
+            
+            // workaround code which is slower but works
+      let decimalNumber = NSDecimalNumber(decimal: value)
+      let numberFormatter = NumberFormatter()
+      numberFormatter.numberStyle = .decimal
+      numberFormatter.locale = locale
+      let string = numberFormatter.string(from: decimalNumber) ?? "\(value)"
+            
       try self.encode(string)
     case .custom(let closure):
       try closure(value, self._encoder)

--- a/sources/declarative/encodable/containers/SingleValueEncodingContainer.swift
+++ b/sources/declarative/encodable/containers/SingleValueEncodingContainer.swift
@@ -191,16 +191,16 @@ extension ShadowEncoder.SingleValueContainer {
   mutating func encode(_ value: Decimal) throws {
     switch self._encoder.sink._withUnsafeGuaranteedRef({ $0.configuration.decimalStrategy }) {
     case .locale(let locale):
-            // original code that falied with XCdoe 16 compiler
-      //var number = value
-      //let string = NSDecimalString(&number, locale)
+            // original code that fails with XCode 16 compiler
+      var number = value
+      let string = NSDecimalString(&number, locale)
             
             // workaround code which is slower but works
-      let decimalNumber = NSDecimalNumber(decimal: value)
-      let numberFormatter = NumberFormatter()
-      numberFormatter.numberStyle = .decimal
-      numberFormatter.locale = locale
-      let string = numberFormatter.string(from: decimalNumber) ?? "\(value)"
+//      let decimalNumber = NSDecimalNumber(decimal: value)
+//      let numberFormatter = NumberFormatter()
+//      numberFormatter.numberStyle = .decimal
+//      numberFormatter.locale = locale
+//      let string = numberFormatter.string(from: decimalNumber) ?? "\(value)"
             
       try self.encode(string)
     case .custom(let closure):


### PR DESCRIPTION
## Description

XCode 16 has an issue with NSDecimalString and will stop the compiler with error:

1.	Apple Swift version 6.0 (swiftlang-6.0.0.9.10 clang-1600.0.26.2)
2.	Compiling with effective version 5.10
3.	While evaluating request ExecuteSILPipelineRequest(Run pipelines { Mandatory Diagnostic Passes + Enabling Optimization Passes } on SIL for CodableCSV)
4.	While running pass #1627 SILModuleTransform "MandatorySILLinker".
5.	While deserializing SIL function "NSDecimalString"
6.	*** DESERIALIZATION FAILURE ***

## Checklist

The following list must only be fulfilled by code-changing PRs. If you are making changes on the documentation, ignore these.

- In SingleValueEncodingContainer.swift, I made the following changes:


  ```
  mutating func encode(_ value: Decimal) throws {
    switch self._encoder.sink._withUnsafeGuaranteedRef({ $0.configuration.decimalStrategy }) {
    case .locale(let locale):

            // original code that failed with XCode 16 compiler
      //var number = value
      //let string = NSDecimalString(&number, locale)

           // workaround code which is slower but works
      let decimalNumber = NSDecimalNumber(decimal: value)
      let numberFormatter = NumberFormatter()
      numberFormatter.numberStyle = .decimal
      numberFormatter.locale = locale
      let string = numberFormatter.string(from: decimalNumber) ?? \(value)
            
      try self.encode(string)
    case .custom(let closure):
      try closure(value, self._encoder)
    }
  }
```



- I think both strings are equivalent, although using a formatter is much slower. Maybe there is a better workaround that you know of.
